### PR TITLE
고객 리뷰 검색 방식 수정

### DIFF
--- a/src/main/kotlin/org/gangneung/ricewinehomepage/implement/review/ReviewReader.kt
+++ b/src/main/kotlin/org/gangneung/ricewinehomepage/implement/review/ReviewReader.kt
@@ -19,8 +19,4 @@ class ReviewReader(
     fun readById(id: Long): Review {
         return reviewRepository.findByIdOrNull(id) ?: throw RuntimeException("존재하지 않는 리뷰입니다.")
     }
-
-    fun search(q: String): List<Review> {
-        return reviewRepository.search(q)
-    }
 }

--- a/src/main/kotlin/org/gangneung/ricewinehomepage/presentation/review/ReviewController.kt
+++ b/src/main/kotlin/org/gangneung/ricewinehomepage/presentation/review/ReviewController.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -52,13 +51,5 @@ class ReviewController(
     ): ApiResponse<Long> {
         val username = user.getUsername()
         return ApiResponse.ok("좋아요 요청 성공", reviewService.likeReview(id, username))
-    }
-
-    @PreAuthorize("isAuthenticated()")
-    @GetMapping("/search")
-    fun search(
-        @RequestParam q: String,
-    ): ApiResponse<List<ReviewResponse>> {
-        return ApiResponse.ok("고객 리뷰 검색 성공", reviewService.search(q))
     }
 }

--- a/src/main/kotlin/org/gangneung/ricewinehomepage/repository/review/CustomReviewRepository.kt
+++ b/src/main/kotlin/org/gangneung/ricewinehomepage/repository/review/CustomReviewRepository.kt
@@ -5,6 +5,4 @@ import org.gangneung.ricewinehomepage.util.CustomPagingRequest
 
 interface CustomReviewRepository {
     fun getReviewList(request: CustomPagingRequest): List<Review>
-
-    fun search(q: String): List<Review>
 }

--- a/src/main/kotlin/org/gangneung/ricewinehomepage/repository/review/CustomReviewRepositoryImpl.kt
+++ b/src/main/kotlin/org/gangneung/ricewinehomepage/repository/review/CustomReviewRepositoryImpl.kt
@@ -15,14 +15,8 @@ class CustomReviewRepositoryImpl(
             .selectFrom(review)
             .offset(request.offset)
             .limit(request.size.toLong())
+            .where(review.title.containsIgnoreCase(request.q))
             .orderBy(*createOrderSpecifier(request.sort))
-            .fetch()
-    }
-
-    override fun search(q: String): List<Review> {
-        return jpaQueryFactory
-            .selectFrom(review)
-            .where(review.title.containsIgnoreCase(q))
             .fetch()
     }
 

--- a/src/main/kotlin/org/gangneung/ricewinehomepage/service/review/ReviewService.kt
+++ b/src/main/kotlin/org/gangneung/ricewinehomepage/service/review/ReviewService.kt
@@ -48,9 +48,4 @@ class ReviewService(
         reviewLikeAppender.append(review, loginUser)
         return review.id!!
     }
-
-    fun search(q: String): List<ReviewResponse> {
-        return reviewReader.search(q)
-            .map { ReviewResponse.toResponse(it) }
-    }
 }

--- a/src/main/kotlin/org/gangneung/ricewinehomepage/util/CustomPagingRequest.kt
+++ b/src/main/kotlin/org/gangneung/ricewinehomepage/util/CustomPagingRequest.kt
@@ -7,6 +7,7 @@ data class CustomPagingRequest(
     var page: Int = 1,
     var size: Int = 10,
     var sort: List<String>,
+    var q: String,
 ) {
     companion object {
         private const val MAX_SIZE = 2000


### PR DESCRIPTION
### 변경사항
- 기존에는 별도의 엔드포인트를 두고 검색하고 싶은 리뷰 제목의 키워드를 입력하면 별도의 쿼리로 DB에서 조회하여 반환하도록 구현
- 변경 후에는 고객 리뷰 전체 조회 쿼리에 where 조건을 넣어서 검색어로 들어온 키워드를 넣어서 조회하도록 구현
- 따라서 기존에 만들었던 검색 요청을 담당하는 엔드포인트 삭제, 쿼리 삭제, 서비스 비즈니스 로직 삭제