### PR TITLE
OAuth Login 관련 수정

### DIFF
--- a/src/main/kotlin/org/gangneung/ricewinehomepage/util/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/gangneung/ricewinehomepage/util/security/config/SecurityConfig.kt
@@ -14,8 +14,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
@@ -43,7 +43,7 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.anyRequest().permitAll()
             }
-            .addFilterBefore(JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterAfter(JwtAuthFilter(jwtUtil), OAuth2LoginAuthenticationFilter::class.java)
             .exceptionHandling {
                 it.authenticationEntryPoint(UnAuthorizedHandler(objectMapper))
                 it.accessDeniedHandler(AccessDeniedHandler(objectMapper))


### PR DESCRIPTION
### 수정사항
- 로컬 환경에서 서버를 실행하고 OAuth2 로그인을 한 뒤 서버를 종료했다가 다시 서버를 실행하고 `http://localhost:8080/` 로 접속했을 때 쿠키에 `Authorization`이 남아있을 경우에 JWT 만료 에러가 발생하는 것을 수정하기 위해 `SecurityConfig`에서 `JwtAuthFilter` 위치를 변경